### PR TITLE
Enhanced Feature Extraction and Output Customization in Capa CLI

### DIFF
--- a/src/extractor/dnfile.rs
+++ b/src/extractor/dnfile.rs
@@ -175,7 +175,7 @@ impl super::Extractor for Extractor {
                     OpCodeValue::Jmp,
                     OpCodeValue::Newobj,
                 ]
-                .contains(&insn.opcode.value)
+                    .contains(&insn.opcode.value)
                 {
                     continue;
                 }
@@ -210,15 +210,15 @@ impl super::Extractor for Extractor {
     ) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
         let f: &Function = f.as_any().downcast_ref::<Function>().unwrap();
         Ok([
-            self.extract_function_call_to_features(f)?,
-            self.extract_function_call_from_features(f)?,
-            self.extract_recurcive_call_features(f)?,
+            self.extract_function_call_to_features(&f)?,
+            self.extract_function_call_from_features(&f)?,
+            self.extract_recurcive_call_features(&f)?,
         ]
-        .into_iter()
-        .fold(Vec::new(), |mut acc, f| {
-            acc.extend(f);
-            acc
-        }))
+            .into_iter()
+            .fold(Vec::new(), |mut acc, f| {
+                acc.extend(f);
+                acc
+            }))
     }
 
     fn get_basic_blocks(
@@ -682,7 +682,7 @@ impl Extractor {
             OpCodeValue::Calli,
             OpCodeValue::Newobj,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             return Ok(vec![]);
         }
@@ -765,7 +765,7 @@ impl Extractor {
             OpCodeValue::Jmp,
             OpCodeValue::Calli,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             let operand_result = resolve_dotnet_token(
                 &self.pe,
@@ -858,7 +858,7 @@ impl Extractor {
             OpCodeValue::Stfld,
             OpCodeValue::Stsfld,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             if let Ok(fields_lock) = self.get_fields() {
                 if let Some(fields) = fields_lock.read().as_ref() {
@@ -955,7 +955,7 @@ impl Extractor {
             OpCodeValue::Stsfld,
             OpCodeValue::Newobj,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             return Ok(vec![]);
         }
@@ -1025,7 +1025,7 @@ impl Extractor {
             OpCodeValue::Stsfld,
             OpCodeValue::Newobj,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             return Ok(vec![]);
         }
@@ -1099,7 +1099,7 @@ impl Extractor {
             OpCodeValue::Jmp,
             OpCodeValue::Calli,
         ]
-        .contains(&insn.opcode.value)
+            .contains(&insn.opcode.value)
         {
             return Ok(vec![]);
         }

--- a/src/extractor/smda.rs
+++ b/src/extractor/smda.rs
@@ -111,7 +111,7 @@ impl super::Extractor for Extractor {
         res.extend(self.extract_file_export_names()?);
         res.extend(self.extract_file_import_names()?);
         res.extend(self.extract_file_section_names()?);
-        res.extend(self._extract_file_embedded_pe()?);
+        res.extend(self.extract_file_embedded_pe()?);
         res.extend(self.extract_file_strings()?);
         //        res.extend(self.extract_file_function_names(pbytes)?);
         res.extend(self.extract_file_format()?);
@@ -334,10 +334,10 @@ impl Extractor {
         Ok(res)
     }
 
-    fn _extract_file_embedded_pe(&self) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
+    fn extract_file_embedded_pe(&self) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
         let mut res = vec![];
         for (mz_offset, _pe_offset, _key) in
-            Extractor::find_embedded_pe_headers(&self.report.buffer)
+        Extractor::find_embedded_pe_headers(&self.report.buffer)
         {
             res.push((
                 crate::rules::features::Feature::Characteristic(


### PR DESCRIPTION
# Enhanced Feature Extraction and Output Customization in Capa CLI

This PR introduces a series of optimizations and enhancements to the Capa CLI tool, focusing on improving the feature extraction process, particularly with .NET files, and adding new CLI options for better output management and feature data inclusion.

## Key Changes

### .NET-Aware Feature Extraction
The feature extraction logic has been optimized to include conditional checks for .NET files, ensuring that file features are accurately extracted based on the file type. This enhances the tool's ability to work with a broader range of executable formats and improves the overall accuracy of the analysis.

### CLI Options for Output Customization

- **JSON Output Path (`-o` or `--output`)**: Users can now specify a custom path for the JSON output using the `-o` or `--output` option followed by the desired file path. This allows for greater flexibility in how and where analysis results are saved. For example, specifying `-o="path_to_json"` will direct the tool to save the JSON output to the specified path.
- **Feature Map Inclusion (`-m` or `--map-features`)**: With the new `--map-features` flag, users can opt to include a comprehensive map of features found during the analysis in the JSON output. This feature is particularly useful for detailed analyses where understanding the specific features matched is crucial. To include the feature map in the JSON output, simply add `--m` to the command line.

## Implementation Details

- The feature collection process now leverages Rust's efficient data handling capabilities to streamline the aggregation and indexing of rule matches, significantly reducing the complexity and improving the performance of the analysis.
- Conditional logic has been added to ensure that file features are only included for .NET files, addressing the unique analysis requirements of these files.
- The introduction of CLI options for output customization provides users with enhanced control over the analysis process, enabling more tailored and detailed examination of binary files.

## Usage

To utilize the new output customization features, you can specify the JSON output path and decide whether to include the feature map in the output as follows:

`capa_cli -o="path_to_json" --m [other options] <file_to_analyze>`