### PR TITLE
Refactor byte extraction to align with capa rules specifications

### DIFF
--- a/src/extractor/dnfile.rs
+++ b/src/extractor/dnfile.rs
@@ -950,21 +950,7 @@ impl Extractor {
         _f: &cil::function::Function,
         insn: &cil::instruction::Instruction,
     ) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
-        if ![
-            OpCodeValue::Call,
-            OpCodeValue::Callvirt,
-            OpCodeValue::Jmp,
-            OpCodeValue::Calli,
-            OpCodeValue::Ldfld,
-            OpCodeValue::Ldflda,
-            OpCodeValue::Ldsfld,
-            OpCodeValue::Ldsflda,
-            OpCodeValue::Stfld,
-            OpCodeValue::Stsfld,
-            OpCodeValue::Newobj,
-        ]
-        .contains(&insn.opcode.value)
-        {
+        if self.check_contains_opcode(insn) {
             return Ok(vec![]);
         }
         let mut res = vec![];
@@ -1025,12 +1011,7 @@ impl Extractor {
         Ok(res)
     }
 
-    ///parse instruction class features
-    pub fn extract_insn_class_features(
-        &self,
-        _f: &cil::function::Function,
-        insn: &cil::instruction::Instruction,
-    ) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
+    fn check_contains_opcode(&self, insn: &cil::instruction::Instruction) -> bool {
         if ![
             OpCodeValue::Call,
             OpCodeValue::Callvirt,
@@ -1046,8 +1027,21 @@ impl Extractor {
         ]
         .contains(&insn.opcode.value)
         {
+            return true;
+        }
+        false
+
+    }
+    ///parse instruction class features
+    pub fn extract_insn_class_features(
+        &self,
+        _f: &cil::function::Function,
+        insn: &cil::instruction::Instruction,
+    ) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
+        if self.check_contains_opcode(insn) {
             return Ok(vec![]);
         }
+
         let mut res = vec![];
         let operand = resolve_dotnet_token(
             &self.pe,

--- a/src/extractor/smda.rs
+++ b/src/extractor/smda.rs
@@ -422,7 +422,7 @@ impl Extractor {
             }
             res.push((
                 crate::rules::features::Feature::String(
-                    crate::rules::features::StringFeature::new(&trimmed, "")?,
+                    crate::rules::features::StringFeature::new(trimmed, "")?,
                 ),
                 a,
             ));
@@ -763,19 +763,14 @@ impl Extractor {
 
     pub fn extract_insn_bytes_features(
         &self,
-        f: &Function,
+        _f: &Function,
         insn: &Instruction,
     ) -> Result<Vec<(crate::rules::features::Feature, u64)>> {
         let mut res = vec![];
-        let instruction_length = insn.bytes.len();
-        let context_based_length = if f.arch == crate::FileArchitecture::AMD64 {
-            std::cmp::min(instruction_length, 16)
-        } else {
-            instruction_length
-        };
+
         for data_ref in insn.get_data_refs(&self.report)? {
             for v in derefs(&self.report, &data_ref)? {
-                let bytes_read = read_bytes(&self.report, &v, context_based_length)?;
+                let bytes_read = read_bytes(&self.report, &v, 0x100)?;
                 if all_zeros(bytes_read)? || is_padding(bytes_read)? {
                     continue;
                 }
@@ -1134,7 +1129,7 @@ pub fn detect_ascii_len(report: &DisassemblyReport, offset: &u64) -> Result<usiz
         .count();
 
     if rva + ascii_len as u64 >= buffer_len {
-        return Err(std::io::Error::new(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             "Buffer overflow detected while detecting ASCII length"
         ))?;
@@ -1300,7 +1295,7 @@ pub fn extract_unicode_strings(data: &[u8], min_length: usize) -> Result<Vec<(St
 }
 
 fn clean_string(s: &str) -> String {
-    s.replace("\u{0000}", "")
+    s.replace('\u{0000}', "")
         .chars()
         .filter(|c| c.is_ascii_graphic() || c.is_ascii_whitespace())
         .collect()

--- a/src/extractor/smda.rs
+++ b/src/extractor/smda.rs
@@ -750,7 +750,7 @@ impl Extractor {
                 res.push((
                     crate::rules::features::Feature::String(
                         crate::rules::features::StringFeature::new(
-                            &trimmed.trim_end_matches('\x00'),
+                            trimmed.trim_end_matches('\x00'),
                             "",
                         )?,
                     ),
@@ -1093,7 +1093,7 @@ pub fn read_string(report: &DisassemblyReport, offset: &u64) -> Result<String> {
     let alen = detect_ascii_len(report, offset)?;
     if alen > 1 {
         let bytes = read_bytes(report, offset, alen)?;
-        return Ok(std::str::from_utf8(&bytes)?.to_string());
+        return Ok(std::str::from_utf8(bytes)?.to_string());
     }
     let ulen = detect_unicode_len(report, offset)?;
     if ulen > 2 {
@@ -1109,16 +1109,17 @@ pub fn read_string(report: &DisassemblyReport, offset: &u64) -> Result<String> {
 
 pub fn detect_ascii_len(report: &DisassemblyReport, offset: &u64) -> Result<usize> {
     let buffer_len = report.buffer.len() as u64;
-    let rva = offset.checked_sub(report.base_addr)
-        .ok_or_else(|| std::io::Error::new(
+    let rva = offset.checked_sub(report.base_addr).ok_or_else(|| {
+        std::io::Error::new(
             std::io::ErrorKind::Other,
-            "Offset is out of bounds relative to the base address"
-        ))?;
+            "Offset is out of bounds relative to the base address",
+        )
+    })?;
 
     if rva as usize >= report.buffer.len() {
-        return Err(std::io::Error::new(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            "RVA is beyond buffer length"
+            "RVA is beyond buffer length",
         ))?;
     }
 
@@ -1131,7 +1132,7 @@ pub fn detect_ascii_len(report: &DisassemblyReport, offset: &u64) -> Result<usiz
     if rva + ascii_len as u64 >= buffer_len {
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            "Buffer overflow detected while detecting ASCII length"
+            "Buffer overflow detected while detecting ASCII length",
         ))?;
     }
 


### PR DESCRIPTION
This PR refactors the extract_insn_bytes_features method, extending the byte read limit to 0x100 to comply with the updated byte sequence matching rules defined in the capa rules documentation (see [capa rules Bytes](https://github.com/mandiant/capa-rules/blob/master/doc/format.md#bytes)). Additionally, a minor refactor on the check_contains_opcode function for improved clarity.
